### PR TITLE
Fix right click crash

### DIFF
--- a/qdatamatrix/translate.py
+++ b/qdatamatrix/translate.py
@@ -18,12 +18,14 @@ along with qdatamatatrix.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 from datamatrix.py3compat import *
-from qtpy.QtCore import QCoreApplication
+from qtpy import QtCore
 
-if py3:
+qt_major_version = int(QtCore.QT_VERSION_STR.split(".")[0])
+
+if py3 or qt_major_version > 4:
 	def _(s):
-		return QCoreApplication.translate(u'qdatamatrix', s)
+		return QtCore.QCoreApplication.translate(u'qdatamatrix', s)
 else:
 	def _(s):
-		return QCoreApplication.translate(u'qdatamatrix', s,
-			encoding=QCoreApplication.UnicodeUTF8)
+		return QtCore.QCoreApplication.translate(u'qdatamatrix', s,
+			encoding=QtCore.QCoreApplication.UnicodeUTF8)


### PR DESCRIPTION
According to https://wiki.qt.io/Transition_from_Qt_4.x_to_Qt5#QCoreApplication::UnicodeUTF8_is_deprecated
QCoreApplication.UnicodeUTF8 is deprecated and completely removed:

> This enum is now obsolete and UTF-8 will be used in all cases.

I have built in a check whether OpenSesame is running with python 3 or Qt5 and in those cases it will omit the encoding argument. This solves the crash for me running on python 2 and Qt5, but I am running the English language version of course, so I have no idea how the context menu will behave if its items contain utf8 characters.
